### PR TITLE
fix: reinitialize non-persistent RoPE buffers after loading

### DIFF
--- a/bacformer/modeling/modeling_base.py
+++ b/bacformer/modeling/modeling_base.py
@@ -461,14 +461,19 @@ class BacformerEncoder(nn.Module):
             dropout=config.attention_probs_dropout_prob,
         )
 
+        freqs_cos, freqs_sin = self._compute_rotary_tables()
+        self.register_buffer("freqs_cos", freqs_cos, persistent=False)
+        self.register_buffer("freqs_sin", freqs_sin, persistent=False)
+
+    def _compute_rotary_tables(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute the analytic rotary tables for this encoder's config."""
         # Note that config.max_position_embeddings is multiplied by 1.5 because the token limit for the Bacformer of
         # models is 6000. Adding this multiplier instead of using 6000 directly allows for dynamism of token
         # lengths while training or fine-tuning.
-        freqs_cos, freqs_sin = precompute_freqs_cis(
-            config.hidden_size // config.num_attention_heads, int(config.max_position_embeddings * 1.5)
+        return precompute_freqs_cis(
+            self.config.hidden_size // self.config.num_attention_heads,
+            int(self.config.max_position_embeddings * 1.5),
         )
-        self.register_buffer("freqs_cos", freqs_cos, persistent=False)
-        self.register_buffer("freqs_sin", freqs_sin, persistent=False)
 
     def forward(
         self,
@@ -530,7 +535,8 @@ class BacformerPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _no_split_modules = ["BacformerEmbeddings", "BacformerTransformerLayer"]
 
-    # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
+    # Adapted from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights,
+    # with an added branch that rebuilds the non-persistent RoPE buffers (#33).
     def _init_weights(self, module):
         """Initialize the weights"""
         if isinstance(module, nn.Linear):
@@ -546,6 +552,11 @@ class BacformerPreTrainedModel(PreTrainedModel):
         elif isinstance(module, nn.LayerNorm):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
+        elif isinstance(module, BacformerEncoder):
+            # Rebuild non-persistent RoPE buffers after meta-device loading (#33).
+            freqs_cos, freqs_sin = module._compute_rotary_tables()
+            module.freqs_cos.copy_(freqs_cos)
+            module.freqs_sin.copy_(freqs_sin)
 
 
 class BacformerModel(BacformerPreTrainedModel):

--- a/bacformer/modeling/modeling_large.py
+++ b/bacformer/modeling/modeling_large.py
@@ -851,6 +851,7 @@ class BacformerLargePreTrainedModel(PreTrainedModel):
         - Linear layers: Normal distribution with std=config.initializer_range
         - Embeddings: Normal distribution with std=config.initializer_range
         - LayerNorm: Weight=1.0, bias=0.0
+        - RotaryEmbedding: Non-persistent `inv_freq` buffer rebuilt analytically
         Args:
             module: The module to initialize.
         """
@@ -866,6 +867,9 @@ class BacformerLargePreTrainedModel(PreTrainedModel):
             if module.bias is not None:
                 module.bias.data.zero_()
             module.weight.data.fill_(1.0)
+        elif isinstance(module, RotaryEmbedding):
+            # Rebuild non-persistent RoPE buffers after meta-device loading (#33).
+            module.inv_freq.copy_(module._compute_inv_freq(module.inv_freq.device))
 
 
 class BacformerLargeModel(BacformerLargePreTrainedModel):

--- a/tests/modeling/test_rotary_buffers.py
+++ b/tests/modeling/test_rotary_buffers.py
@@ -1,0 +1,100 @@
+import torch
+from bacformer.modeling.config import BacformerConfig
+from bacformer.modeling.modeling_base import BacformerModel
+from bacformer.modeling.modeling_large import BacformerLargeConfig, BacformerLargeModel
+
+
+def _base_config():
+    return BacformerConfig(
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        hidden_size=8,
+        intermediate_size=16,
+        hidden_dropout_prob=0.0,
+        attention_probs_dropout_prob=0.0,
+        max_position_embeddings=8,
+        max_token_type_embeddings=4,
+        protein_clusters_vocab_size=8,
+    )
+
+
+def _large_config():
+    return BacformerLargeConfig(
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        hidden_size=8,
+        hidden_dropout_prob=0.0,
+        attention_probs_dropout_prob=0.0,
+        max_position_embeddings=8,
+        max_token_type_embeddings=4,
+        protein_clusters_vocab_size=8,
+    )
+
+
+def _expected_base_buffers(config):
+    dim = config.hidden_size // config.num_attention_heads
+    end = int(config.max_position_embeddings * 1.5)
+    inv_freq = 1 / (10000.0 ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    freqs = torch.outer(torch.arange(end, dtype=torch.float32), inv_freq)
+    return torch.cos(freqs), torch.sin(freqs)
+
+
+def _expected_large_buffer(config):
+    dim = config.hidden_size // config.num_attention_heads
+    return 1 / (10000.0 ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+
+
+def test_base_init_hook_reconstructs_rotary_buffers():
+    with torch.device("meta"):
+        model = BacformerModel(_base_config())
+    model.to_empty(device="cpu")
+    model.encoder.freqs_cos.zero_()
+    model.encoder.freqs_sin.zero_()
+
+    model._init_weights(model.encoder)
+
+    expected_cos, expected_sin = _expected_base_buffers(model.config)
+    torch.testing.assert_close(model.encoder.freqs_cos, expected_cos, rtol=0, atol=0)
+    torch.testing.assert_close(model.encoder.freqs_sin, expected_sin, rtol=0, atol=0)
+    assert not any("freqs_cos" in key or "freqs_sin" in key for key in model.state_dict())
+
+
+def test_large_init_hook_reconstructs_all_rotary_buffers():
+    with torch.device("meta"):
+        model = BacformerLargeModel(_large_config())
+    model.to_empty(device="cpu")
+    expected = _expected_large_buffer(model.config)
+
+    for layer in model.encoder.layers:
+        layer.attn.rotary.inv_freq.zero_()
+        model._init_weights(layer.attn.rotary)
+
+    for layer in model.encoder.layers:
+        torch.testing.assert_close(layer.attn.rotary.inv_freq, expected, rtol=0, atol=0)
+    assert not any("inv_freq" in key for key in model.state_dict())
+
+
+def test_base_rotary_buffers_are_reconstructed_after_pretrained_round_trip(tmp_path):
+    model = BacformerModel(_base_config()).eval()
+    expected_cos, expected_sin = _expected_base_buffers(model.config)
+    torch.testing.assert_close(model.encoder.freqs_cos, expected_cos, rtol=0, atol=0)
+    torch.testing.assert_close(model.encoder.freqs_sin, expected_sin, rtol=0, atol=0)
+
+    model.save_pretrained(tmp_path)
+    loaded = BacformerModel.from_pretrained(tmp_path).eval()
+
+    torch.testing.assert_close(loaded.encoder.freqs_cos, expected_cos, rtol=0, atol=0)
+    torch.testing.assert_close(loaded.encoder.freqs_sin, expected_sin, rtol=0, atol=0)
+
+
+def test_large_rotary_buffers_are_reconstructed_after_pretrained_round_trip(tmp_path):
+    model = BacformerLargeModel(_large_config()).eval()
+    expected = _expected_large_buffer(model.config)
+    for layer in model.encoder.layers:
+        torch.testing.assert_close(layer.attn.rotary.inv_freq, expected, rtol=0, atol=0)
+
+    model.save_pretrained(tmp_path)
+    loaded = BacformerLargeModel.from_pretrained(tmp_path).eval()
+
+    for layer in loaded.encoder.layers:
+        torch.testing.assert_close(layer.attn.rotary.inv_freq, expected, rtol=0, atol=0)


### PR DESCRIPTION
Addresses #33.

**Deployment note up front:** the README and tutorial inference paths load
Hub-side remote code from the `macwiatrak/bacformer-*` Hugging Face
repositories. Merging this repository PR does not by itself update those
copies. They need the same patch, so I would suggest keeping #33 open until
that synchronization is complete.

## Summary

- Reconstruct the Base model's `freqs_cos` and `freqs_sin` tables in its
  Transformers initialization hook.
- Reconstruct every Large model `RotaryEmbedding.inv_freq` buffer in the same
  lifecycle.
- Add deterministic regression tests for meta-device materialization and
  local `save_pretrained` / `from_pretrained` round trips.

The buffers remain `persistent=False`, so this does not change checkpoint keys
or the state-dict schema. The implementation copies analytic values into the
materialized buffers, preserving their registered device and dtype.

## Why

In the affected Transformers 5 loading path, Bacformer can be constructed on
the meta device and its non-persistent RoPE buffers later materialized with
empty storage. Because those buffers are intentionally absent from the
checkpoint, no checkpoint tensor overwrites that storage. Depending on the
allocation, inference can then fail loudly or return finite but incorrect
outputs.

Transformers calls the model's initialization hook after missing tensors and
non-persistent buffers are materialized. These new branches use that existing
lifecycle to rebuild only the deterministic RoPE buffers.

The root cause was originally reported by @fire537 in #33. I independently
reproduced it and added version-boundary, silent-output, and released-checkpoint
controls in
https://github.com/macwiatrak/Bacformer/issues/33#issuecomment-5081809572.

## Validation

- On this branch all four new tests pass with PyTorch 2.5.1 under Transformers
  4.38.2, 4.56.2, 5.1.0, 5.4.0, and 5.14.1.
- On unmodified `main` at `305a782`, the two `save_pretrained` /
  `from_pretrained` round-trip tests **fail on 5.1.0, 5.4.0 and 5.14.1 and pass
  on 4.38.2 and 4.56.2** — the same version boundary as the underlying bug.
  Where they fail, `loaded.encoder.freqs_cos` comes back all zeros (24/24 values
  mismatched, maximum absolute error 1.0) and every Large `inv_freq` buffer is
  zeroed. The two meta-device tests fail on `main` on all five versions, since
  the rebuild they exercise does not exist there.

  | Transformers | this branch | unmodified `main` |
  | --- | --- | --- |
  | 4.38.2 | 4 passed | 2 failed, 2 passed |
  | 4.56.2 | 4 passed | 2 failed, 2 passed |
  | 5.1.0 | 4 passed | **4 failed** |
  | 5.4.0 | 4 passed | **4 failed** |
  | 5.14.1 | 4 passed | **4 failed** |

  These four tests assert only on the RoPE buffers, so a green row is not by
  itself a statement about overall model correctness on that version.

- With the released Base MAG (`17b98674`), Base complete-genome (`6c8d83de`),
  and current Large MAG (`589fda44`) checkpoints, Transformers 4.56.2 and
  5.14.1 load every encoder state-dict tensor exactly, reconstruct every tested
  RoPE buffer with zero analytic error, and produce checkpoint-specific
  bit-identical FP32 output hashes when PyTorch is held at 2.5.1.
- The focused 5.1.0 and 5.4.0 results establish RoPE reconstruction only. On
  those two versions, that same `save_pretrained` / `from_pretrained` path
  silently re-initializes every loaded parameter — 19 of 19 `BacformerModel`
  state-dict tensors change, against 0 of 23 for a stock `BertModel` in the same
  environment — with no warning, and with `output_loading_info` returning empty
  `missing_keys` / `unexpected_keys` / `mismatched_keys` / `error_msgs`. That
  behavior is pre-existing, reproduces on unpatched `main`, and is not addressed
  here. Released-checkpoint parity is therefore claimed only for 4.56.2 and
  5.14.1.
- Base and Large buffer reconstruction are exact on Apple MPS in bfloat16
  (maximum absolute error 0.0 against the analytic values cast to the same
  device and dtype).
- Ruff lint and formatting, Python compilation, and diff checks pass.
- Measured on the documented user path for reference, since it exercises the
  Hub-side copy of the modeling code rather than this repository:
  `AutoModel.from_pretrained("macwiatrak/bacformer-masked-MAG",
  trust_remote_code=True)` at revision `17b98674` (the current default) returns
  corrupt RoPE tables on every Transformers 5 version I tried. On 5.1.0 and
  5.14.1, `freqs_cos` came back with tens of thousands of NaNs out of 270,000
  entries and the model output was entirely NaN. On 5.4.0 the result varied
  between processes: one run produced NaNs, two produced an all-zero table,
  which gives finite but meaningless output. 4.56.2 was clean in all runs. This
  is why I think #33 should stay open until the Hub copies are updated.

In the full `tests/modeling` run under Transformers 5.14.1, this branch gives
9 passed and 4 failed out of 13, and unmodified `main` gives 5 passed and the
same 4 failures out of its 9 tests. Those four pretraining failures are
identical on both sides and come from the pre-existing `all_tied_weights_keys`
incompatibility. This PR does not modify `modeling_pretraining.py` or address
that separate loader issue.

## Deployment follow-up

The documented user path loads model code from the Hugging Face checkpoint
repositories with `trust_remote_code=True`. Merging this repository PR alone
will not update those remote modeling files. After merge, the corresponding
Base and Large Hugging Face repositories should receive the same fix in new
revisions. A model-card warning for older immutable revisions would also help
prevent silent use of the affected code.
